### PR TITLE
Column offsets with push and pull classes

### DIFF
--- a/demo/demo.scss
+++ b/demo/demo.scss
@@ -88,9 +88,37 @@ a {
   }
 }
 
+code {
+  background: #efefef;
+  padding: 0.2em 0.5em;
+  font-family: Courier,  monospace;
+}
+
+pre {
+  font-family: Courier,  monospace;
+}
+
 .demo-title-description {
   color: $btn-tertiary-bg;
 }
 .demo-text-size {
   color: $btn-primary-bg;
+}
+
+.box {
+  padding: $spacer * 2;
+  color: #fff;
+  min-height: 200px;
+}
+
+.u-bg-primary {
+  background: $btn-primary-bg;
+}
+
+.u-bg-secondary {
+  background: $btn-secondary-bg;
+}
+
+.u-bg-tertiary {
+  background: $btn-tertiary-bg;
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -250,6 +250,57 @@
       </div> <!-- /.col-md-10 -->
     </div> <!-- /.row -->
 
+    <!-- Grid Column Offsets -->
+    <section class="pv-2 pv-md-4">
+      <div class="row">
+        <div class="col-xs-12">
+          <h2>Grid Column Offsets</h2>
+
+          <p class="text--md">
+            You can use <code class="text--xs">.col-&lt;bp&gt;-push-&lt;number&gt;</code>
+            to push and pull columns. This can be used to center a layout, e.g.
+            a 10/12 centered layout, or to create an overlapping magazine-style layout.
+          </p>
+          <p class="text--xs">
+            Creating a 10/12 centered layout is easier without using offsets,
+            you can add the class <code class="text--xxs">row--center</code>, e.g.
+            <code class="text--xxs">row row--center</code> like the font size section above.
+          </p>
+          <p class="text--md">
+            You can see the columns layout with the <a href="https://chrome.google.com/webstore/detail/base-layers/fhkhleopmmdiokahobpnchddheokcldd" target="_blank" rel="noopener">
+              Base Layers Chrome extension
+            </a>.
+          </p>
+        </div>
+      </div>
+
+      <div class="row mt-4">
+        <div class="col-xs-12 col-md-3 col-md-push-1">
+          <div class="box u-bg-primary mv-2">
+            <pre class="text--xs">col-xs-12 col-md-3 col-md-push-1</pre>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4 col-md-pull-1">
+          <div class="box u-bg-secondary mv-2 mt-md-10">
+            <pre class="text--xs">col-xs-12 col-md-4 col-md-pull-1</pre>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4 col-md-pull-1">
+          <div class="box u-bg-tertiary mv-2 mt-md-20">
+            <pre class="text--xs">col-xs-12 col-md-4 col-md-pull-1</pre>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-3 col-md-pull-2">
+          <div class="box u-bg-primary mv-2 mt-md-30">
+            <pre class="text--xs">col-xs-12 col-md-3 col-md-pull-2</pre>
+          </div>
+        </div>
+      </div>
+    </section>
+
   </div>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "base-layers",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-layers",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The foundation of your website's outfit 👙",
   "main": "scss/base-layers.scss",
   "scripts": {

--- a/scss/utils/_grid.scss
+++ b/scss/utils/_grid.scss
@@ -67,6 +67,14 @@
   padding-right: $gutter/2;
 }
 
+@mixin column-push-offset($columns, $total-columns: $grid-column-count) {
+  margin-left: percentage($columns / $total-columns);
+}
+
+@mixin column-pull-offset($columns, $total-columns: $grid-column-count) {
+  margin-left: -#{percentage($columns / $total-columns)};
+}
+
 
 //////////////////////////
 // Grid
@@ -75,12 +83,31 @@
 
 @mixin make-default-columns($columns: $grid-column-count, $gutter: $grid-gutter, $classname: col) {
   @for $i from 1 through $columns {
+    // Column sizes
     .#{$classname}-#{$i} {
       @include column($i, $gutter, $total-columns: $columns);
     }
 
     .#{$classname}-xs-#{$i} {
       @include column($i, $gutter, $total-columns: $columns);
+    }
+
+    // Column push offsets
+    .#{$classname}-push-#{$i} {
+      @include column-push-offset($i, $total-columns: $columns);
+    }
+
+    .#{$classname}-xs-push-#{$i} {
+      @include column-push-offset($i, $total-columns: $columns);
+    }
+
+    // Column pull offsets
+    .#{$classname}-pull-#{$i} {
+      @include column-pull-offset($i, $total-columns: $columns);
+    }
+
+    .#{$classname}-xs-pull-#{$i} {
+      @include column-pull-offset($i, $total-columns: $columns);
     }
   }
 }
@@ -91,8 +118,19 @@
   $breakpoint-value: map-get($breakpoints-up, $breakpoint-key);
 
   @for $i from 1 through $columns {
+    // Column sizes
     .#{$classname}-#{$breakpoint-key}-#{$i} {
       @include column($i, $gutter, $total-columns: $columns);
+    }
+
+    // Column push offsets
+    .#{$classname}-#{$breakpoint-key}-push-#{$i} {
+      @include column-push-offset($i, $total-columns: $columns);
+    }
+
+    // Column pull offsets
+    .#{$classname}-#{$breakpoint-key}-pull-#{$i} {
+      @include column-pull-offset($i, $total-columns: $columns);
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/tinacious/base-layers/issues/7 

Adds support to offset columns for each breakpoint.

Results in code that offsets columns using positive and negative margins.

![image](https://user-images.githubusercontent.com/1856992/101964148-43fa3800-3bc5-11eb-9f0e-970e5e4df315.png)


![image](https://user-images.githubusercontent.com/1856992/101964104-144b3000-3bc5-11eb-828c-3436e88f5688.png)

Here's an example with the grid overlay (from [this Chrome extension](https://chrome.google.com/webstore/detail/base-layers/fhkhleopmmdiokahobpnchddheokcldd))

![image](https://user-images.githubusercontent.com/1856992/101964191-6b510500-3bc5-11eb-9bff-f3ea56114497.png)

Preview: https://deploy-preview-8--base-layers.netlify.app/